### PR TITLE
Us75 borrower start page

### DIFF
--- a/features/step_definitions/us55_borrower_verified_landing_page.rb
+++ b/features/step_definitions/us55_borrower_verified_landing_page.rb
@@ -1,5 +1,5 @@
 Given(/^I reach the Borrower Identity Verified Page$/) do
-  visit(Env.borrower_frontend)
+  visit(Env.borrower_frontend + '/identity-verified')
 end
 
 Then(/^I should see the "([^"]*)" button$/) do |link|

--- a/features/step_definitions/us75_borrower_start_page.rb
+++ b/features/step_definitions/us75_borrower_start_page.rb
@@ -1,0 +1,3 @@
+Given(/^I reach the borrower start page$/) do
+  visit('http://charges-prototype-ci.herokuapp.com/citizen')
+end

--- a/features/step_definitions/us75_borrower_start_page.rb
+++ b/features/step_definitions/us75_borrower_start_page.rb
@@ -1,3 +1,11 @@
 Given(/^I reach the borrower start page$/) do
-  visit('http://charges-prototype-ci.herokuapp.com/citizen')
+  visit(Env.borrower_frontend)
+end
+
+Then(/^when I click on the "([^"]*)" button$/) do |link_button|
+  page.click_link(link_button)
+end
+
+Then(/^I should reach the borrower identity verified page$/) do
+  expect(page).to have_content('Identity verified')
 end

--- a/features/support/config.rb
+++ b/features/support/config.rb
@@ -15,7 +15,7 @@ Capybara.default_driver = :poltergeist
 Capybara.javascript_driver = :poltergeist
 
 Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, inspector: true, js_errors: true)
+  Capybara::Poltergeist::Driver.new(app, inspector: true, js_errors: false)
 end
 
 require 'test/unit'

--- a/features/us75_borrower_start_page.feature
+++ b/features/us75_borrower_start_page.feature
@@ -9,6 +9,9 @@ Scenario Outline: Borrower arrives start page
     Given I reach the borrower start page
     Then I should see the "Start now" button
     And the following <Texts> should be displayed
+    And when I click on the "Start now" button
+    Then I should reach the borrower identity verified page
+
 
     Examples:
       | Texts                                                                 |

--- a/features/us75_borrower_start_page.feature
+++ b/features/us75_borrower_start_page.feature
@@ -1,0 +1,17 @@
+@us75
+
+Feature: Check content on Borrower Start Page
+
+Acceptance Criteria
+    Page content matches wireframe
+
+Scenario Outline: Borrower arrives start page
+    Given I reach the borrower start page
+    Then I should see the "Start now" button
+    And the following <Texts> should be displayed
+
+    Examples:
+      | Texts                                                                 |
+      | "Sign your mortgage deed"                                             |
+      | "To verify your identity using GOV.UK Verify"                         |
+      | "Why is the government involved in this?"                             |


### PR DESCRIPTION
Finished acceptance tests for us75, also checks to make sure the start now link button arrives at identity verified landing page.

Changed us55's end point to reflect new url
