### PR TITLE
added checks to old tests to verify error messages are returned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+.idea/
 
 ## Specific to RubyMotion:
 .dat*

--- a/features/us40_add_md_ref.feature
+++ b/features/us40_add_md_ref.feature
@@ -13,8 +13,9 @@ Scenario: Create a deed with two Mortgage Document references
   Given I have deed data with two md refs
   When I create the deed via the Deed API
   Then a status code of "400" is returned
+  And a message for failure is given "Failed validating 'pattern' in schema['properties']['md_ref']:"
 
-Scenario: Create a deed with an invalid mortgage document reference
+  Scenario: Create a deed with an invalid mortgage document reference
   Given I have deed data with an md ref made of a six digit number
   When I create the deed via the Deed API
   Then a status code of "400" is returned

--- a/features/us6_add_title_number_to_deed.feature
+++ b/features/us6_add_title_number_to_deed.feature
@@ -13,8 +13,10 @@ Scenario: Add Multiple Title Numbers
   Given I have deed data with two title numbers
   When I create the deed via the Deed API
   Then a status code of "400" is returned
+  And a message for failure is given "Failed validating 'pattern' in schema['properties']['title_number']:"
 
 Scenario: Add Invalid Title Number
   Given I have deed data with an invalid format title number
   When I create the deed via the Deed API
   Then a status code of "400" is returned
+  And a message for failure is given "Failed validating 'pattern' in schema['properties']['title_number']:"


### PR DESCRIPTION
This is a copy of the changes Mandy made https://github.com/LandRegistry/dm-acceptance-tests/pull/19 but weren't merged it got two +1 from Ender and myself, so was all reviewed. There was just a gnarly rebase as it was merged after a later chore that changed develop quite considerably, so it was simpler as it was only a 3 line change just to branch off current develop and redo the changes.
