### PR TITLE
refactored tests to test optional middle name correctly

### DIFF
--- a/features/data/deed.rb
+++ b/features/data/deed.rb
@@ -23,7 +23,6 @@ class Deed
     number_of_borrowers.times do |borrower_number|
       borrowers.push(
         forename: 'Jayne',
-        middle_name: '',
         surname: 'Cobb',
         gender: "#{/Male|Female|Not Specified/.random_example}",
         address: "#{borrower_number}B Borrower Street, Plymouth, PL3 2PP",

--- a/features/step_definitions/us13_borrowers_personal_info.rb
+++ b/features/step_definitions/us13_borrowers_personal_info.rb
@@ -81,7 +81,6 @@ Given(/^I have deed data with two borrowers one which has no gender$/) do
       },
       {
         forename: 'Paul',
-        middle_name: '',
         surname: 'Smythe',
         address: '1 The High Street Highley PL6 7TG',
         dob: '29/09/2000',


### PR DESCRIPTION
This pull request changed the optional middle name to not use the tuple when it is not provided instead of providing a blank tuple as per business rule
