### PR TITLE
added teardown for esec to acceptance tests

### DIFF
--- a/esec_teardown/server.py
+++ b/esec_teardown/server.py
@@ -12,13 +12,9 @@ _create_unverified_https_context = ssl._create_unverified_context
 
 logging.basicConfig(filename="./esec-delete.log", level=logging.DEBUG)
 
-url = os.getenv('ESEC_URL')
-adminUrl = os.getenv('ESEC_ADMIN_URL')
-userServicesUrl = os.getenv('USER_SERVICE_URL')
-
-client = Client(url)
-adminClient = Client(adminUrl)
-userClient = Client(userServicesUrl)
+client = Client(os.getenv('ESEC_URL'))
+adminClient = Client(os.getenv('ESEC_ADMIN_URL'))
+userClient = Client(os.getenv('USER_SERVICE_URL'))
 
 doTheDelete = False
 ORGANISATION_ID = "TESTUT2 [36812]"

--- a/esec_teardown/server.py
+++ b/esec_teardown/server.py
@@ -8,13 +8,9 @@ import os
 
 LOGGER = logging.getLogger(__name__)
 
-# This tells the SSL runtime to trust the provided certificate without credentials
 _create_unverified_https_context = ssl._create_unverified_context
 
 logging.basicConfig(filename="./esec-delete.log", level=logging.DEBUG)
-
-# TODO: Ensure the domain name is in the /windows/system32/drivers/etc/hosts file
-#url = 'https://TST-ESEC-H204.tst.esec.net:8443/routerProject/services/DocumentServices?wsdl'
 
 url = os.getenv('ESEC_URL')
 adminUrl = os.getenv('ESEC_ADMIN_URL')

--- a/esec_teardown/server.py
+++ b/esec_teardown/server.py
@@ -1,0 +1,76 @@
+from suds.client import Client
+import ssl
+import sys
+import argparse
+import logging
+import os
+
+
+LOGGER = logging.getLogger(__name__)
+
+# This tells the SSL runtime to trust the provided certificate without credentials
+_create_unverified_https_context = ssl._create_unverified_context
+
+logging.basicConfig(filename="./esec-delete.log", level=logging.DEBUG)
+
+# TODO: Ensure the domain name is in the /windows/system32/drivers/etc/hosts file
+#url = 'https://TST-ESEC-H204.tst.esec.net:8443/routerProject/services/DocumentServices?wsdl'
+
+url = os.getenv('ESEC_URL')
+adminUrl = os.getenv('ESEC_ADMIN_URL')
+userServicesUrl = os.getenv('USER_SERVICE_URL')
+
+client = Client(url)
+adminClient = Client(adminUrl)
+userClient = Client(userServicesUrl)
+
+doTheDelete = False
+ORGANISATION_ID = "TESTUT2 [36812]"
+
+print("client initialised")
+
+requestId = os.getenv('REQUEST_ID')
+
+
+def process_input_options():
+    parser = argparse.ArgumentParser(prog='esec_delete_users',
+                                     description='Detele users in esecurity.')
+    parser.add_argument('confirm_delete', default='.', metavar='False',
+                        help='Set to "True" to do the delete ')
+    parser.add_argument('organisation_name', metavar='organisation_name',
+                        help='name of the LDAP organisation e.g Digital Mortgage, TESTUT2 [36812]')
+    settings = parser.parse_args()
+    return settings
+
+
+def run_delete():
+    LOGGER.info("ESEC delete init")
+    settings = process_input_options()
+    LOGGER.info("Settings from command line: %s" % str(settings))
+    ORGANISATION_ID = settings.organisation_name
+
+    #old account = LR Administrators
+    res = adminClient.service.searchForUser(requestId, "*", "GB", ORGANISATION_ID, "Users")
+
+    for user in res:
+        user_name = user["userId"]
+        #print("User Name: %s %s %s - status: %s" % (user_name, user["commonName"], user["surname"], user["accountStatus"]))
+
+        if user_name[0:3] == "dm-":
+
+            if user["accountStatus"] == "Active":
+                print("Deleting user: %s" % user["userId"])
+                try:
+                    if settings.confirm_delete == "True":
+                        res = adminClient.service.removeUser(requestId, user["userId"])
+                        print("Remove user: %s - %s " % (user["userId"],str(res)))
+                    else:
+                        print("Remove user(TEST- NOT DELETED): %s - %s " % (user["userId"],0))
+                except:
+                    msg = str(sys.exc_info())
+                    print(msg)
+                    print("Error: Removing user: %s" % (user["userId"]))
+
+
+if __name__ == "__main__":
+    run_delete()

--- a/esec_teardown/server.py
+++ b/esec_teardown/server.py
@@ -45,12 +45,10 @@ def run_delete():
     LOGGER.info("Settings from command line: %s" % str(settings))
     ORGANISATION_ID = settings.organisation_name
 
-    #old account = LR Administrators
     res = adminClient.service.searchForUser(requestId, "*", "GB", ORGANISATION_ID, "Users")
 
     for user in res:
         user_name = user["userId"]
-        #print("User Name: %s %s %s - status: %s" % (user_name, user["commonName"], user["surname"], user["accountStatus"]))
 
         if user_name[0:3] == "dm-":
 

--- a/esec_teardown/server.py
+++ b/esec_teardown/server.py
@@ -57,13 +57,13 @@ def run_delete():
                 try:
                     if settings.confirm_delete == "True":
                         res = adminClient.service.removeUser(requestId, user["userId"])
-                        print("Remove user: %s - %s " % (user["userId"],str(res)))
+                        LOGGER.info("Remove user: %s - %s " % (user["userId"],str(res)))
                     else:
-                        print("Remove user(TEST- NOT DELETED): %s - %s " % (user["userId"],0))
+                        LOGGER.error("Remove user(TEST- NOT DELETED): %s - %s " % (user["userId"],0))
                 except:
                     msg = str(sys.exc_info())
                     print(msg)
-                    print("Error: Removing user: %s" % (user["userId"]))
+                    LOGGER.error(("Error: Removing user: %s" % (user["userId"])))
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 psycopg2==2.5.4
 SQLAlchemy==1.0.9
+suds

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -20,3 +20,7 @@ if [ -z "$@"]
 else
   BUNDLE_GEMFILE=$gemfile bundle exec cucumber $currentLocation $@
 fi
+
+if [ -z "$ESEC_INTEGRATION"]; then
+    python3 server.py True "Digital Mortgage"
+fi


### PR DESCRIPTION
Adds a python module to remove all users created in security as part of the acceptance test run. runs once after all tests if the environment is integration 
